### PR TITLE
Make badges clickable and up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # async-minecraft-ping
 
-![crates.io](https://img.shields.io/crates/v/async-minecraft-ping)
-![docs.rs](https://docs.rs/async-minecraft-ping/badge.svg?version=0.1.0)
+[![crates.io](https://img.shields.io/crates/v/async-minecraft-ping)][crate]
+[![docs.rs](https://docs.rs/async-minecraft-ping/badge.svg)][docs]
 ![crates.io](https://img.shields.io/crates/l/async-minecraft-ping/0.1.0)
 
 An async [ServerListPing](https://wiki.vg/Server_List_Ping) client implementation in Rust.
@@ -42,3 +42,6 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[crate]: https://crates.io/crates/async-minecraft-ping
+[docs]: https://docs.rs/async-minecraft-ping


### PR DESCRIPTION
I didn't change the license stuff because you'd have to use a different system to always define "latest" as your crate revision.