### PR TITLE
Remove anyhow and use pure thiserror impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["minecraft", "mc", "serverlistping"]
 categories = ["asynchronous", "api-bindings"]
 
 [dependencies]
-anyhow = "1.0"
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Simulates the anyhow<thiserror<Error>> matryoshka for contexts by
implementing this via kind-parent error types.

Closes #7 