### PR TITLE
Don't die when length is invalid(0)

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -195,6 +195,11 @@ impl<R: AsyncRead + Unpin + Send + Sync> AsyncReadRawPacket for R {
             .read_varint()
             .await
             .context("failed to read packet length")?;
+
+        if length == 0 {
+            bail!("packet length is invalid");
+        }
+
         let packet_id = self
             .read_varint()
             .await


### PR DESCRIPTION
It's possible for the returned length to be 0. I don't fully understand why this happens(I don't fully understand the codebase) but the result is an overflow error on line 212 in debug mode, or attempting to allocate a huge array in release mode. This adds a quick check and bails if the length is invalid.